### PR TITLE
Add health check scripts for the security services

### DIFF
--- a/scripts/security-proxy-setup-checker.sh
+++ b/scripts/security-proxy-setup-checker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -ex
+
+/consul/scripts/consul-svc-healthy.sh kong
+
+# setup jq paths to check if kong has the required certificate uploaded to it
+cd /consul/scripts || exit 1
+LD_LIBRARY_PATH=.
+export LD_LIBRARY_PATH
+if [ "1" != "$(curl -s http://kong:8001/certificates | /consul/scripts/jq -r '.data | map(select(."snis" == ["edgex-kong"])) | length')" ]; then
+    exit 2
+fi

--- a/scripts/security-secrets-setup-checker.sh
+++ b/scripts/security-secrets-setup-checker.sh
@@ -1,0 +1,6 @@
+#!/bin/sh -ex
+
+# check that the root CA exists, the vault and kong certs exist
+test -f /vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem
+test -f /vault/config/pki/EdgeXFoundryCA/edgex-vault.pem
+test -f /vault/config/pki/EdgeXFoundryCA/edgex-kong.pem

--- a/scripts/security-secretstore-setup-checker.sh
+++ b/scripts/security-secretstore-setup-checker.sh
@@ -1,0 +1,11 @@
+#!/bin/sh -ex
+
+# for now check that the root token exists
+# TODO: check that individual tokens exist when we don't use the root token 
+# anymore
+test -f /vault/config/assets/resp-init.json
+
+/consul/scripts/consul-svc-healthy.sh security-secrets-setup
+
+# vault will be reported as healthy when it is unsealed
+/consul/scripts/consul-svc-healthy.sh vault


### PR DESCRIPTION
With https://github.com/edgexfoundry/docker-edgex-volume/pull/11, we will now have service definitions for the various security setup services. This PR adds the checks referenced from that PR to docker-edgex-consul image so that when Consul runs it is able to run these scripts as needed.

The next step after this towards fixing #1710 is to overwrite the entrypoint/command for the security services in docker-compose to wait on their dependencies with the pattern we have already established for Kong and related services here. The PR doing that is open here: https://github.com/edgexfoundry/developer-scripts/pull/172. However, that PR also has a dependency on edgex-go to change the security-proxy-setup-go Docker image to use Alpine so we can run `/bin/sh` and `curl`, as well as a change adding `curl` to the security-secretstore-setup Docker image. That PR is https://github.com/edgexfoundry/edgex-go/pull/2075.

The developer-scripts PR at https://github.com/edgexfoundry/developer-scripts/pull/172 will have full testing instructions for how to test this change along with the other PR's.

See https://github.com/edgexfoundry/edgex-go/issues/1710 for full details on this task.