### PR TITLE
consul-svc-healthy: use system jq if available

### DIFF
--- a/scripts/consul-svc-healthy.sh
+++ b/scripts/consul-svc-healthy.sh
@@ -3,8 +3,16 @@
 
 cd /consul/scripts || exit 1
 
-LD_LIBRARY_PATH=.
-export LD_LIBRARY_PATH
-if ! [ "true" = "$(curl -s -G edgex-core-consul:8500/v1/agent/checks | /consul/scripts/jq -r '.[] | select(.ServiceName == "'"$1"'") | .Status == "passing"')" ]; then
+# use JQ from path if it exists (i.e. on ubuntu), otherwise use from consul
+# scripts dir with local LD_LIBRARY_PATH to load libonig from there too
+JQ=$(command -v jq)
+if [ -z "$JQ" ]; then
+    LD_LIBRARY_PATH=.
+    export LD_LIBRARY_PATH
+    JQ=/consul/scripts/jq
+fi
+export JQ
+
+if ! [ "true" = "$(curl -s -G edgex-core-consul:8500/v1/agent/checks | "$JQ" -r '.[] | select(.ServiceName == "'"$1"'") | .Status == "passing"')" ]; then
     exit 2
 fi


### PR DESCRIPTION
If we have a system jq, for example on some images jq is already installed, use that one instead of trying to use the one from the consul-scripts volume because that one will only work with Alpine/musl based images.
For example the docker-edgex-mongo image needs to use this script but has Ubuntu as a base image which is glibc based and thus incompatible with the jq we have staged in the consul-scripts volume. So for that image, we should instead use jq from the base image.