### PR TITLE
Update the security-secrets-checker script

### DIFF
--- a/scripts/security-serets-setup-checker.sh
+++ b/scripts/security-serets-setup-checker.sh
@@ -1,0 +1,5 @@
+#!/bin/sh -ex
+
+# check that the security-secrets-setup complete
+# the new way of checking just the sentinel files which will have all TLS assets
+test -f /tmp/edgex/secrets/ca/.security-secrets-setup.complete


### PR DESCRIPTION
Use the new path `/tmp/edgex/secrets/*` for checking the sentinel files due to the change of splitting vault images and compatibility on MacOs + Linux

Related to fixing [edgex-go issue #1716](https://github.com/edgexfoundry/edgex-go/issues/1716), on step 3 of PR [edgexfoundry#2146](https://github.com/edgexfoundry/edgex-go/pull/2146)

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>