### PR TITLE
Fix the error of shell script naming

### DIFF
--- a/scripts/security-secrets-setup-checker.sh
+++ b/scripts/security-secrets-setup-checker.sh
@@ -1,6 +1,5 @@
 #!/bin/sh -ex
 
-# check that the root CA exists, the vault and kong certs exist
-test -f /vault/config/pki/EdgeXFoundryCA/EdgeXFoundryCA.pem
-test -f /vault/config/pki/EdgeXFoundryCA/edgex-vault.pem
-test -f /vault/config/pki/EdgeXFoundryCA/edgex-kong.pem
+# check that the security-secrets-setup complete
+# the new way of checking just the sentinel files which will have all TLS assets
+test -f /tmp/edgex/secrets/ca/.security-secrets-setup.complete

--- a/scripts/security-serets-setup-checker.sh
+++ b/scripts/security-serets-setup-checker.sh
@@ -1,5 +1,0 @@
-#!/bin/sh -ex
-
-# check that the security-secrets-setup complete
-# the new way of checking just the sentinel files which will have all TLS assets
-test -f /tmp/edgex/secrets/ca/.security-secrets-setup.complete


### PR DESCRIPTION
  The PR #10 is meant to update the content of `scripts/security-secrets-setup-checker.sh` but mis-spelled as `scripts/security-serets-setup-checker.sh`

This PR fixes the problem.

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>