### PR TITLE
Update consul version and deploy in prod mode.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,6 @@
 ###############################################################################
 # Copyright 2019 Canonical.
+# Copyright 2019 Intel Corporation.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -38,13 +39,14 @@ COPY . .
 RUN make build
 
 # consul upstream is based on alpine
-FROM consul:1.3.1
+FROM consul:1.7.0
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
-    copyright='Copyright (c) 2019: Canonical'
+    copyright='Copyright (c) 2019: Canonical; \
+Copyright (c) 2019: Intel Corporation'
 
 # for pg_isready to check when kong-db is ready
-RUN apk add postgresql-client jq curl
+RUN apk add postgresql-client jq=1.6-r0 curl=7.64.0-r3
 
 COPY scripts /consul/scripts
 COPY --from=builder /go/src/github.com/edgexfoundry/docker-edgex-consul/health /consul/scripts/health
@@ -58,3 +60,6 @@ RUN cp /usr/lib/libonig.so* /consul/scripts/
 # consul ports
 EXPOSE 8500
 EXPOSE 8400
+
+# Override consul defaults so that container runs in production mode by default
+CMD [ "agent", "-ui", "-bootstrap", "-server", "-client", "0.0.0.0" ]


### PR DESCRIPTION
Update consul version and deploy in prod mode.

Fixes #1.  (originally https://github.com/edgexfoundry/edgex-go/issues/1935)
Fixes #15. (Consul version bump)

Bump the consul version to the latest
and override the CMD argument so that it deploys
in production mode--the default for Consul
is to deploy in -dev mode.  In -dev mode,
consul forgets it state between runs.

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>