### PR TITLE
fix[security-services]: Address race condition for mongodb initialization

### DIFF
--- a/scripts/security-secretstore-setup-checker.sh
+++ b/scripts/security-secretstore-setup-checker.sh
@@ -1,11 +1,8 @@
 #!/bin/sh -ex
 
-# for now check that the root token exists
-# TODO: check that individual tokens exist when we don't use the root token 
-# anymore
-test -f /vault/config/assets/resp-init.json
-
-/consul/scripts/consul-svc-healthy.sh security-secrets-setup
-
 # vault will be reported as healthy when it is unsealed
 /consul/scripts/consul-svc-healthy.sh vault
+
+# If SECRETSTORE_SETUP_DONE_FLAG not defined, pass; else
+# If SECRETSTORE_SETUP_DONE_FLAG file doesn't exist, error
+test -z "${SECRETSTORE_SETUP_DONE_FLAG}" || test -f "${SECRETSTORE_SETUP_DONE_FLAG}"


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/edgex-go/issues/2383
Fixes https://github.com/edgexfoundry/docker-edgex-consul/issues/21

This fix addresses a race condition for mongodb initialization
wherein the secret store is set up, but has not generated
per-sevice Vault tokens, nor committed mongodb passwords to
the secret store.  This fix introduces a sentinel file that
is used to indicate secretstore-setup completion without
giving access to the secretstore to an untrusted component (consul),
AND also removes the dependence on a sensitive file (resp-init.json).

Signed-off-by: Bryon Nevis <bryon.nevis@intel.com>