### PR TITLE
fix[core,security-services]: Consul health check

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,7 +39,7 @@ COPY . .
 RUN make build
 
 # consul upstream is based on alpine
-FROM consul:1.7.0
+FROM consul:1.7.2
 
 LABEL license='SPDX-License-Identifier: Apache-2.0' \
     copyright='Copyright (c) 2019: Canonical; \
@@ -48,8 +48,13 @@ Copyright (c) 2019: Intel Corporation'
 # for pg_isready to check when kong-db is ready
 RUN apk add postgresql-client jq=1.6-r0 curl=7.64.0-r3
 
-COPY scripts /consul/scripts
-COPY --from=builder /go/src/github.com/edgexfoundry/docker-edgex-consul/health /consul/scripts/health
+# Make sure the default directories are created for consul
+RUN mkdir -p /consul/scripts && mkdir -p /consul/config
+
+# Inject EdgeX config/scripts into the image
+COPY scripts /edgex/scripts
+COPY config /edgex/config
+COPY --from=builder /go/src/github.com/edgexfoundry/docker-edgex-consul/health /edgex/scripts/health
 
 # be sneaky and sneak jq into the scripts dir for now, eventually need a 
 # statically compiled go program so we don't have to deal with musl/glibc issues
@@ -60,6 +65,10 @@ RUN cp /usr/lib/libonig.so* /consul/scripts/
 # consul ports
 EXPOSE 8500
 EXPOSE 8400
+
+# Copy over custom entrypoint (derived from consul entrypoint)
+COPY edgex-consul-entrypoint.sh /usr/local/bin/edgex-consul-entrypoint.sh
+ENTRYPOINT ["edgex-consul-entrypoint.sh"]
 
 # Override consul defaults so that container runs in production mode by default
 CMD [ "agent", "-ui", "-bootstrap", "-server", "-client", "0.0.0.0" ]

--- a/Makefile
+++ b/Makefile
@@ -37,13 +37,6 @@ health:
 
 docker: $(DOCKERS)
 
-clean:
-
-test:
-
-run:
-	./bin/edgex-consul-launch.sh
-
 edgex-consul:
 	 docker build \
 		-f Dockerfile \

--- a/config/00-consul.json
+++ b/config/00-consul.json
@@ -1,0 +1,3 @@
+{
+    "enable_local_script_checks": true
+}

--- a/config/database/01-mongo.json
+++ b/config/database/01-mongo.json
@@ -1,0 +1,18 @@
+{
+  "service": {
+      "name": "edgex-mongo",
+      "tags": [
+          "database",
+          "nosql"
+      ],
+	  "address": "edgex-mongo",
+      "port": 27017,
+      "check": {
+          "name": "status",
+          "tcp": "edgex-mongo:27017",
+          "interval": "10s",
+		  "timeout": "1s"
+      }
+   }
+}
+

--- a/config/database/01-redis.json
+++ b/config/database/01-redis.json
@@ -1,0 +1,18 @@
+{
+    "service": {
+        "name": "edgex-redis",
+        "tags": [
+            "database"
+        ],
+        "address": "edgex-redis",
+        "port": 6379,
+        "check": {
+            "name": "status",
+            "tcp": "edgex-redis:6379",
+            "interval": "10s",
+            "timeout": "1s"
+        }
+     }
+  }
+  
+  

--- a/config/secure/02-kong-db.json
+++ b/config/secure/02-kong-db.json
@@ -1,0 +1,20 @@
+{
+  "service": {
+    "id": "kong-db",
+    "name": "kong-db",
+    "tags": [
+      "database"
+    ],
+    "checks": [
+      {
+        "name": "Health Check: kong-db (postgres)",
+        "args": [
+          "/consul/scripts/kong-db-checker.sh"
+        ],
+        "interval": "1s",
+        "timeout": "1s",
+        "service_id": "kong-db"
+      }
+    ]
+  }
+}

--- a/config/secure/02-kong-migrations.json
+++ b/config/secure/02-kong-migrations.json
@@ -1,0 +1,17 @@
+{
+  "service": {
+    "id": "kong-migrations",
+    "name": "kong-migrations",
+    "checks": [
+      {
+        "name": "Health Check: kong-migrations",
+        "args": [
+          "/consul/scripts/kong-migrations-checker.sh"
+        ],
+        "interval": "1s",
+        "timeout": "1s",
+        "service_id": "kong-migrations"
+      }
+    ]
+  }
+}

--- a/config/secure/02-kong.json
+++ b/config/secure/02-kong.json
@@ -1,0 +1,18 @@
+{
+  "service": {
+    "id": "kong",
+    "name": "kong",
+    "address": "kong",
+    "port": 8001,
+    "checks": [
+      {
+        "name": "Health Check: kong",
+        "http": "http://kong:8001/status",
+        "method": "GET",
+        "interval": "1s",
+        "timeout": "1s",
+        "service_id": "kong"
+      }
+    ]
+  }
+}

--- a/config/secure/02-security-proxy-setup.json
+++ b/config/secure/02-security-proxy-setup.json
@@ -1,0 +1,17 @@
+{
+    "service": {
+        "id": "security-proxy-setup",
+        "name": "security-proxy-setup",
+        "checks": [
+            {
+                "name": "Health Check: security-proxy-setup",
+                "args": [
+                    "/consul/scripts/security-proxy-setup-checker.sh"
+                ],
+                "interval": "1s",
+                "timeout": "1s",
+                "service_id": "security-proxy-setup"
+            }
+        ]
+    }
+}

--- a/config/secure/02-security-secrets-setup.json
+++ b/config/secure/02-security-secrets-setup.json
@@ -1,0 +1,17 @@
+{
+    "service": {
+        "id": "security-secrets-setup",
+        "name": "security-secrets-setup",
+        "checks": [
+            {
+                "name": "Health Check: security-secrets-setup",
+                "args": [
+                    "/consul/scripts/security-secrets-setup-checker.sh"
+                ],
+                "interval": "1s",
+                "timeout": "1s",
+                "service_id": "security-secrets-setup"
+            }
+        ]
+    }
+}

--- a/config/secure/02-security-secretstore-setup.json
+++ b/config/secure/02-security-secretstore-setup.json
@@ -1,0 +1,17 @@
+{
+    "service": {
+        "id": "security-secretstore-setup",
+        "name": "security-secretstore-setup",
+        "checks": [
+            {
+                "name": "Health Check: security-secretstore-setup",
+                "args": [
+                    "/consul/scripts/security-secretstore-setup-checker.sh"
+                ],
+                "interval": "1s",
+                "timeout": "1s",
+                "service_id": "security-secretstore-setup"
+            }
+        ]
+    }
+}

--- a/edgex-consul-entrypoint.sh
+++ b/edgex-consul-entrypoint.sh
@@ -1,0 +1,32 @@
+#!/bin/sh
+set -e
+
+Database_Check="${EDGEX_DB:-redis}"
+Secure_Check="${EDGEX_SECURE:-true}"
+
+# Set default config
+cp /edgex/config/00-consul.json /consul/config/00-consul.json
+
+# Set config files - Redis DB
+if [ "$Database_Check" = 'redis' ]; then
+    echo "Installing redis health checks"
+    cp /edgex/config/database/01-redis.json /consul/config/01-redis.json
+fi
+
+# Set config files - Mongo DB
+if [ "$Database_Check" = 'mongo' ]; then
+    echo "Installing mongo health checks"
+    cp /edgex/config/database/01-mongo.json /consul/config/01-mongo.json
+fi
+
+# Set config files - Secure Setup
+if [ "$Secure_Check" = 'true' ]; then
+    echo "Installing security health checks"
+    cp /edgex/config/secure/*.json /consul/config/
+fi
+
+# Copy health check scripts
+cp -r /edgex/scripts/* /consul/scripts/
+
+echo "Chaining to original entrypoint"
+exec "docker-entrypoint.sh" "$@"


### PR DESCRIPTION
Fixes https://github.com/edgexfoundry/developer-scripts/issues/242
Fixes https://github.com/edgexfoundry/developer-scripts/issues/220
Fixes https://github.com/edgexfoundry/developer-scripts/issues/213

The Dockerfile was updated in several ways. First, the source consul
image version was incremented from 1.7.0 to 1.7.2. The creation of
default consul directories (/consul/scripts & /consul/config) are now
created in a single RUN line. There are new "edgex" directories to house
scripts & config files under /edgex that are filled with assets from the
root build directory. This creates a cleaner image that is only
initialized with config and script files that are relevant at run time.

Brings me to my next point - an additional entrypoint script was
prepended to the existing entrypoint script (that is inherited from the
consul image). This new entrypoint script (edgex-consul-entrypoint.sh)
handles the initialization (movement) of config & script files to the
default consul directories based on a few new environment variables that
show up in the docker-compose files. If there are no environment
variables, there are defaults set for the variables and default files
are copied over at run time to start the consul image up. All command
flags sent to this entrypoint are sent along to the default consul image
entrypoint script and are processed as normal. The Dockerfile injects
the new entrypoint script and the Dockerfile points to the new script as
its default entrypoint.

The Make file was simply cleaned up and I removed the "clean", "test",
and "run" options - given they were either blank or invalid.

Lastly, there is a new directory called "config" that contains all of
the base JSON configuration files that are utilized to setup the checks
for in consul. I also added a new one to check redis. The files are
named with 2 digits at the beginning of the file name so that we have
*some* control over the order in which they are loaded in to consul.
Double zero ("00") gets loaded first and sets the stage to load all of
the other configurations.

Signed-off-by: Beau Frusetta <beau.frusetta@intel.com>