### PR TITLE
feat(security): Remove Vault's healthy check in Consul

### DIFF
--- a/scripts/security-secretstore-setup-checker.sh
+++ b/scripts/security-secretstore-setup-checker.sh
@@ -1,7 +1,11 @@
 #!/bin/sh -ex
 
 # vault will be reported as healthy when it is unsealed
-/consul/scripts/consul-svc-healthy.sh vault
+# NOTE: comment out the vault healthy check below after we switch Vault to use 
+# file backend as the check becomes superfluous
+# the real check "SECRETSTORE_SETUP_DONE_FLAG" below already 
+# waited on Vault successfully initialized at the first place
+#/consul/scripts/consul-svc-healthy.sh vault
 
 # If SECRETSTORE_SETUP_DONE_FLAG not defined, pass; else
 # If SECRETSTORE_SETUP_DONE_FLAG file doesn't exist, error


### PR DESCRIPTION
With the Vault's backend being changed from consul to filesystem, Vault's healthy check now becomes superfluous.

The original automatically generated healthy check in Vault now is gone due to Vault's backend storage is not dependent on Consul any more.

This together with edgex-go's change shall remove the dependency of Vault from Consul.

Signed-off-by: Jim Wang <yutsung.jim.wang@intel.com>

## PR Checklist
Please check if your PR fulfills the following requirements:

- [ ] Tests for the changes have been added (for bug fixes / features)
- [ ] Docs have been added / updated (for bug fixes / features)

**If your build fails** due to your commit message not passing the build checks, please review the guidelines here: https://github.com/edgexfoundry/docker-edgex-consul/blob/master/.github/Contributing.md.



## What is the current behavior?
<!-- Please describe the current behavior and link to a relevant issue. -->
Vault's healthy check within Consul

## Issue Number: edgexfoundry/edgex-go#2882 


## What is the new behavior?
No Vault's healthy check directly from Consul

## Does this PR introduce a breaking change?
<!-- If this PR contains a breaking change, please describe the impact and migration path for existing applications below. -->

- [ ] Yes
- [X] No

## Specific Instructions
Are there any specific instructions or things that should be known prior to reviewing?


## Other information
Related to https://github.com/edgexfoundry/edgex-go/issues/2882 
Also see PR: https://github.com/edgexfoundry/edgex-go/pull/2886 
